### PR TITLE
Fixed namespace pollution, added CMake install, fixed SIOClientImpl::receive static buffer issue #9

### DIFF
--- a/socket.io-poco/CMakeLists.txt
+++ b/socket.io-poco/CMakeLists.txt
@@ -3,3 +3,8 @@ cmake_minimum_required(VERSION 2.8.9)
 project(socketiopoco)
 set(CMAKE_BUILD_TYPE Release) # or Debug
 add_subdirectory (src)
+
+file(GLOB SIOPOCO_HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h")
+
+INSTALL(FILES ${SIOPOCO_HEADERS}
+  DESTINATION include/socketio-poco/)

--- a/socket.io-poco/CMakeLists.txt
+++ b/socket.io-poco/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 2.8.7)
 
 project(socketiopoco)
 set(CMAKE_BUILD_TYPE Release) # or Debug

--- a/socket.io-poco/include/SIOClient.h
+++ b/socket.io-poco/include/SIOClient.h
@@ -1,11 +1,12 @@
-#pragma once
+#ifndef SIOCLIENT_HPP_
+#define SIOCLIENT_HPP_
 
 #include "SIOClientImpl.h"
-
 #include "Poco/JSON/Object.h"
 
-using Poco::JSON::Object;
-
+namespace sio_poco
+{
+	
 class SIOClient
 {
 private:
@@ -16,7 +17,7 @@ private:
 	std::string _uri;
 	std::string _endpoint;
 
-	NotificationCenter* _nCenter;
+	Poco::NotificationCenter* _nCenter;
 
 	SIOEventRegistry *_registry;
 	SIONotificationHandler *_sioHandler; 
@@ -31,11 +32,14 @@ public:
 	void send(std::string s);
 	void emit(std::string eventname, std::string args);
 	std::string getUri();
-	NotificationCenter* getNCenter();
+	Poco::NotificationCenter* getNCenter();
 
-	typedef void (SIOEventTarget::*callback)(const void*, Object::Ptr&);
+	typedef void (SIOEventTarget::*callback)(const void*, Poco::JSON::Object::Ptr&);
 
 	void on(const char *name, SIOEventTarget *target, callback c);
 
-	void fireEvent(const char * name, Object::Ptr args);
+	void fireEvent(const char * name, Poco::JSON::Object::Ptr args);
 };
+}
+
+#endif

--- a/socket.io-poco/include/SIOClientImpl.h
+++ b/socket.io-poco/include/SIOClientImpl.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef SIOCLIENTIMPL_HPP_
+#define SIOCLIENTIMPL_HPP_
 
 #include <string>
 
@@ -18,18 +19,8 @@
 #include "SIOEventTarget.h"
 
 
-using Poco::JSON::Object;
-
-using Poco::Net::HTTPClientSession;
-using Poco::Net::WebSocket;
-using Poco::Logger;
-using Poco::Timer;
-using Poco::TimerCallback;
-using Poco::NotificationCenter;
-using Poco::Thread;
-using Poco::ThreadTarget;
-
-
+namespace sio_poco
+{
 class SIOClientImpl: public Poco::Runnable
 {
 private:
@@ -46,11 +37,11 @@ private:
 	bool _connected;
 	
 
-	HTTPClientSession *_session;
-	WebSocket *_ws;
-	Timer *_heartbeatTimer;
-	Logger *_logger;
-	Thread _thread;
+	Poco::Net::HTTPClientSession *_session;
+	Poco::Net::WebSocket *_ws;
+	Poco::Timer *_heartbeatTimer;
+	Poco::Logger *_logger;
+	Poco::Thread _thread;
 
 	int _refCount;
 	
@@ -78,3 +69,6 @@ public:
 
 	std::string getUri();
 };
+}
+
+#endif

--- a/socket.io-poco/include/SIOClientImpl.h
+++ b/socket.io-poco/include/SIOClientImpl.h
@@ -45,6 +45,9 @@ private:
 
 	int _refCount;
 	
+	char *_buffer;
+	std::size_t _buffer_size;
+	
 	//SIOEventRegistry* _registry;
 	//SIONotificationHandler *_sioHandler;
 

--- a/socket.io-poco/include/SIOClientRegistry.h
+++ b/socket.io-poco/include/SIOClientRegistry.h
@@ -1,7 +1,11 @@
-#pragma once
+#ifndef SIOCLIENTREGISTRY_HPP_
+#define SIOCLIENTREGISTRY_HPP_
 
 #include <map>
 #include <string>
+
+namespace sio_poco
+{
 
 class SIOClient;
 class SIOClientImpl;
@@ -29,4 +33,5 @@ public:
 	void removeSocket(std::string uri);
 	
 };
-
+}
+#endif

--- a/socket.io-poco/include/SIOEventRegistry.h
+++ b/socket.io-poco/include/SIOEventRegistry.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef SIOEVENTREGISTRY_HPP_
+#define SIOEVENTREGISTRY_HPP_
 
 #include "SIOEventTarget.h"
 #include <map>
@@ -8,11 +9,10 @@
 #include "Poco/BasicEvent.h"
 #include "Poco/Delegate.h"
 
-using Poco::JSON::Object;
-using Poco::BasicEvent;
-using Poco::Delegate;
+namespace sio_poco
+{
 
-typedef void (SIOEventTarget::*callback)(const void*, Object::Ptr&);
+typedef void (SIOEventTarget::*callback)(const void*, Poco::JSON::Object::Ptr&);
 
 class SIOClient;
 
@@ -24,9 +24,11 @@ public:
 
 	//static SIOEventRegistry *sharedInstance();
 	bool registerEvent(const char *name, SIOEventTarget *target, callback c);
-	void fireEvent(SIOClient *client, const char *name, Object::Ptr data);
+	void fireEvent(SIOClient *client, const char *name, Poco::JSON::Object::Ptr data);
 
 private:
 
-	std::map<std::string, BasicEvent< Object::Ptr > *> mEventMap; //!< the map containing event names and handlers
+	std::map<std::string, Poco::BasicEvent< Poco::JSON::Object::Ptr > *> mEventMap; //!< the map containing event names and handlers
 };
+}
+#endif

--- a/socket.io-poco/include/SIOEventTarget.h
+++ b/socket.io-poco/include/SIOEventTarget.h
@@ -1,8 +1,10 @@
-#pragma once
+#ifndef SIOEVENTTARGET_HPP_
+#define SIOEVENTTARGET_HPP_
 
 #include "Poco/JSON/Object.h"
 
-using Poco::JSON::Object;
+namespace sio_poco
+{
 
 class SIOEventTarget
 {
@@ -13,3 +15,5 @@ public:
 	
 	
 };
+}
+#endif

--- a/socket.io-poco/include/SIONotificationHandler.h
+++ b/socket.io-poco/include/SIONotificationHandler.h
@@ -1,28 +1,32 @@
-#pragma once
+#ifndef SIONOTIFICATIONHANDLER_HPP_
+#define SIONOTIFICATIONHANDLER_HPP_
+
 #include "Poco/NotificationCenter.h"
 #include "SIONotifications.h"
 #include "Poco/Logger.h"
 
-using Poco::NotificationCenter;
-using Poco::Logger;
+namespace sio_poco
+{
 
 class SIONotificationHandler
 {
 public:
 	SIONotificationHandler(void);
-	SIONotificationHandler(NotificationCenter* nc);
+	SIONotificationHandler(Poco::NotificationCenter* nc);
 	~SIONotificationHandler(void);
 
 	void handleMessage(SIOMessage* pNf);
 	void handleJSONMessage(SIOJSONMessage* pNf);
 	void handleEvent(SIOEvent* pNf);
 
-	void registerCallbacks(NotificationCenter* nc);
+	void registerCallbacks(Poco::NotificationCenter* nc);
 
-	NotificationCenter* _nCenter;
+	Poco::NotificationCenter* _nCenter;
 
-	Logger *_logger;
+	Poco::Logger *_logger;
 
-	void setNCenter(NotificationCenter* nc);
+	void setNCenter(Poco::NotificationCenter* nc);
 };
+}
 
+#endif

--- a/socket.io-poco/include/SIONotifications.h
+++ b/socket.io-poco/include/SIONotifications.h
@@ -1,11 +1,15 @@
-#pragma once
+
+#ifndef SIONOTIFICATIONS_HPP_
+#define SIONOTIFICATIONS_HPP_
+
 #include "Poco/Notification.h"
 
-using Poco::Notification;
+namespace sio_poco
+{
 
 class SIOClient;
 
-class SIOMessage: public Notification
+class SIOMessage: public Poco::Notification
 {
 public:
 	SIOMessage(std::string msg) : _msg(msg) {}
@@ -14,7 +18,7 @@ private:
 	std::string _msg;
 };
 
-class SIOJSONMessage: public Notification
+class SIOJSONMessage: public Poco::Notification
 {
 public:
 	SIOJSONMessage(std::string msg) : _msg(msg) {}
@@ -23,7 +27,7 @@ private:
 	std::string _msg;
 };
 
-class SIOEvent: public Notification
+class SIOEvent: public Poco::Notification
 {
 public:
 	SIOEvent(SIOClient *client, std::string data) : _client(client), _data(data) {}
@@ -31,3 +35,5 @@ public:
 	SIOClient *_client;
 	std::string _name, _data;
 };
+}
+#endif

--- a/socket.io-poco/src/CMakeLists.txt
+++ b/socket.io-poco/src/CMakeLists.txt
@@ -5,3 +5,7 @@ include_directories("${CMAKE_SOURCE_DIR}/include" /usr/local/include)
 link_directories(/usr/local/lib)
 add_library(socketiopoco SHARED ${SIOPOCO_SOURCES})
 target_link_libraries(socketiopoco PocoFoundation PocoJSON PocoNet)
+
+INSTALL(TARGETS socketiopoco
+  LIBRARY DESTINATION lib
+)

--- a/socket.io-poco/src/SIOClient.cpp
+++ b/socket.io-poco/src/SIOClient.cpp
@@ -3,9 +3,11 @@
 
 #include "Poco/URI.h"
 
+using Poco::NotificationCenter;
 using Poco::URI;
+using Poco::JSON::Object;
 
-SIOClient::SIOClient(std::string uri, std::string endpoint, SIOClientImpl *impl)
+sio_poco::SIOClient::SIOClient(std::string uri, std::string endpoint, SIOClientImpl *impl)
 	: _uri(uri), _endpoint(endpoint), _socket(impl)
 {
 	_socket->addref();
@@ -16,7 +18,7 @@ SIOClient::SIOClient(std::string uri, std::string endpoint, SIOClientImpl *impl)
 	_registry = new SIOEventRegistry();
 }
 
-SIOClient::~SIOClient() {
+sio_poco::SIOClient::~SIOClient() {
 	_socket->release();
 	delete(_sioHandler);
 	delete(_nCenter);
@@ -25,7 +27,8 @@ SIOClient::~SIOClient() {
 	SIOClientRegistry::instance()->removeClient(_uri);
 }
 
-SIOClient* SIOClient::connect(std::string uri) {
+sio_poco::SIOClient* 
+sio_poco::SIOClient::connect(std::string uri) {
 
 	//check if connection to endpoint exists 
 	URI tmp_uri(uri);
@@ -67,38 +70,45 @@ SIOClient* SIOClient::connect(std::string uri) {
 
 }
 
-void SIOClient::disconnect() {
+void 
+sio_poco::SIOClient::disconnect() {
 	_socket->disconnect(_endpoint);
 	delete this;
 }
 
-std::string SIOClient::getUri() {
+std::string 
+sio_poco::SIOClient::getUri() {
 
 	return _uri;
 
 }
 
-NotificationCenter* SIOClient::getNCenter() {
+NotificationCenter* 
+sio_poco::SIOClient::getNCenter() {
 	return _nCenter;
 }
 
-void SIOClient::on(const char *name, SIOEventTarget *target, callback c) {
+void 
+sio_poco::SIOClient::on(const char *name, SIOEventTarget *target, callback c) {
 	_registry->registerEvent(name, target, c);
 }
 
-void SIOClient::fireEvent(const char * name, Object::Ptr args) {
+void 
+sio_poco::SIOClient::fireEvent(const char * name, Object::Ptr args) {
 
 	_registry->fireEvent(this, name, args);
 
 }
 
-void SIOClient::send(std::string s) {
+void 
+sio_poco::SIOClient::send(std::string s) {
 
 	_socket->send(_endpoint, s);
 
 }
 
-void SIOClient::emit(std::string eventname, std::string args) {
+void 
+sio_poco::SIOClient::emit(std::string eventname, std::string args) {
 
 	_socket->emit(_endpoint, eventname, args);
 

--- a/socket.io-poco/src/SIOClientImpl.cpp
+++ b/socket.io-poco/src/SIOClientImpl.cpp
@@ -36,13 +36,14 @@ using Poco::TimerCallback;
 using Poco::Dynamic::Var;
 using Poco::Net::WebSocket;
 using Poco::URI;
+using Poco::Logger;
 
 
-SIOClientImpl::SIOClientImpl() {
+sio_poco::SIOClientImpl::SIOClientImpl() {
 	SIOClientImpl("localhost", 3000);
 }
 
-SIOClientImpl::SIOClientImpl(std::string host, int port) :
+sio_poco::SIOClientImpl::SIOClientImpl(std::string host, int port) :
 	_port(port),
 	_host(host),
 	_refCount(0)
@@ -54,7 +55,7 @@ SIOClientImpl::SIOClientImpl(std::string host, int port) :
 
 }
 
-SIOClientImpl::~SIOClientImpl(void) {
+sio_poco::SIOClientImpl::~SIOClientImpl(void) {
 	
 	_thread.join();
 
@@ -69,7 +70,8 @@ SIOClientImpl::~SIOClientImpl(void) {
 	SIOClientRegistry::instance()->removeSocket(_uri);
 }
 
-bool SIOClientImpl::init() {
+bool 
+sio_poco::SIOClientImpl::init() {
 	_logger = &(Logger::get("SIOClientLog"));
 
 	if(handshake()) 
@@ -83,7 +85,8 @@ bool SIOClientImpl::init() {
 
 }
 
-bool SIOClientImpl::handshake() {
+bool 
+sio_poco::SIOClientImpl::handshake() {
 	UInt16 aport = _port;
 	_session = new HTTPClientSession(_host, aport);
 
@@ -126,7 +129,8 @@ bool SIOClientImpl::handshake() {
 	return false;
 }
 
-bool SIOClientImpl::openSocket() {
+bool 
+sio_poco::SIOClientImpl::openSocket() {
 
 	UInt16 aport = _port;
 	HTTPRequest req(HTTPRequest::HTTP_GET,"/socket.io/1/websocket/"+_sid,HTTPMessage::HTTP_1_1);
@@ -167,7 +171,8 @@ bool SIOClientImpl::openSocket() {
 }
 
 
-SIOClientImpl* SIOClientImpl::connect(std::string host, int port) {
+sio_poco::SIOClientImpl* 
+sio_poco::SIOClientImpl::connect(std::string host, int port) {
 
 	SIOClientImpl *s = new SIOClientImpl(host, port);
 
@@ -180,7 +185,8 @@ SIOClientImpl* SIOClientImpl::connect(std::string host, int port) {
 	return NULL;
 }
 
-void SIOClientImpl::disconnect(std::string endpoint) {
+void 
+sio_poco::SIOClientImpl::disconnect(std::string endpoint) {
 	std::string s = "0::" + endpoint;
 
 	if(endpoint == "") {
@@ -193,7 +199,8 @@ void SIOClientImpl::disconnect(std::string endpoint) {
 	_ws->sendFrame(s.data(), s.size());
 }
 
-void SIOClientImpl::connectToEndpoint(std::string endpoint) {
+void 
+sio_poco::SIOClientImpl::connectToEndpoint(std::string endpoint) {
 
 	std::string s = "1::" + endpoint;	
 
@@ -201,7 +208,8 @@ void SIOClientImpl::connectToEndpoint(std::string endpoint) {
 
 }
 
-void SIOClientImpl::heartbeat(Poco::Timer& timer) {
+void 
+sio_poco::SIOClientImpl::heartbeat(Poco::Timer& timer) {
 	_logger->information("heartbeat called\n");
 
 	std::string s = "2::";
@@ -210,13 +218,15 @@ void SIOClientImpl::heartbeat(Poco::Timer& timer) {
 
 }
 
-void SIOClientImpl::run() {
+void 
+sio_poco::SIOClientImpl::run() {
 
 	monitor();
 
 }
  
-void SIOClientImpl::monitor() {
+void 
+sio_poco::SIOClientImpl::monitor() {
 	do 
 	{
 		receive();
@@ -224,7 +234,8 @@ void SIOClientImpl::monitor() {
 	} while (_connected);
 }
 
-void SIOClientImpl::send(std::string endpoint, std::string s) {
+void 
+sio_poco::SIOClientImpl::send(std::string endpoint, std::string s) {
 	_logger->information("sending message\n");
 
 	std::stringstream pre;
@@ -237,7 +248,8 @@ void SIOClientImpl::send(std::string endpoint, std::string s) {
 
 }
 
-void SIOClientImpl::emit(std::string endpoint, std::string eventname, std::string args) {
+void 
+sio_poco::SIOClientImpl::emit(std::string endpoint, std::string eventname, std::string args) {
 	_logger->information("emitting event\n");
 
 	std::stringstream pre;
@@ -252,7 +264,8 @@ void SIOClientImpl::emit(std::string endpoint, std::string eventname, std::strin
 
 }
 
-bool SIOClientImpl::receive() {
+bool 
+sio_poco::SIOClientImpl::receive() {
 
 	char buffer[1024];
 	int flags;
@@ -275,7 +288,7 @@ bool SIOClientImpl::receive() {
 	std::string uri = _uri;
 	uri += endpoint;
 
-	SIOClient *c = SIOClientRegistry::instance()->getClient(uri);
+	sio_poco::SIOClient *c = SIOClientRegistry::instance()->getClient(uri);
 
 	std::string payload = "";
 
@@ -325,10 +338,12 @@ bool SIOClientImpl::receive() {
 
 }
 
-void SIOClientImpl::addref() {
+void 
+sio_poco::SIOClientImpl::addref() {
 	_refCount++;
 }
 
-void SIOClientImpl::release() {
+void 
+sio_poco::SIOClientImpl::release() {
 	if(--_refCount == 0) delete this;
 }

--- a/socket.io-poco/src/SIOClientRegistry.cpp
+++ b/socket.io-poco/src/SIOClientRegistry.cpp
@@ -1,9 +1,11 @@
 #include "SIOClientRegistry.h"
 #include "SIOClient.h"
 
-SIOClientRegistry *SIOClientRegistry::_inst = NULL;
+sio_poco::SIOClientRegistry *
+sio_poco::SIOClientRegistry::_inst = NULL;
 
-SIOClientRegistry *SIOClientRegistry::instance() {
+sio_poco::SIOClientRegistry *
+sio_poco::SIOClientRegistry::instance() {
 	
 	if(!_inst)
 		_inst = new SIOClientRegistry();
@@ -12,7 +14,8 @@ SIOClientRegistry *SIOClientRegistry::instance() {
 
 }
 
-SIOClient *SIOClientRegistry::getClient(std::string uri) {
+sio_poco::SIOClient *
+sio_poco::SIOClientRegistry::getClient(std::string uri) {
 
 	SIOClient *c = NULL;
 
@@ -28,17 +31,20 @@ SIOClient *SIOClientRegistry::getClient(std::string uri) {
 
 }
 
-void SIOClientRegistry::addClient(SIOClient *client) {
+void 
+sio_poco::SIOClientRegistry::addClient(SIOClient *client) {
 
 	_clientMap[client->getUri()] = client;
 
 }
 
-void SIOClientRegistry::removeClient(std::string uri) {
+void 
+sio_poco::SIOClientRegistry::removeClient(std::string uri) {
 	_clientMap.erase(uri);
 }
 
-SIOClientImpl *SIOClientRegistry::getSocket(std::string uri) {
+sio_poco::SIOClientImpl *
+sio_poco::SIOClientRegistry::getSocket(std::string uri) {
 
 	SIOClientImpl *c = NULL;
 
@@ -54,12 +60,14 @@ SIOClientImpl *SIOClientRegistry::getSocket(std::string uri) {
 
 }
 
-void SIOClientRegistry::addSocket(SIOClientImpl *socket, std::string uri) {
+void 
+sio_poco::SIOClientRegistry::addSocket(SIOClientImpl *socket, std::string uri) {
 
 	_socketMap[uri] = socket;
 
 }
 
-void SIOClientRegistry::removeSocket(std::string uri) {
+void 
+sio_poco::SIOClientRegistry::removeSocket(std::string uri) {
 	_socketMap.erase(uri);
 }

--- a/socket.io-poco/src/SIOEventRegistry.cpp
+++ b/socket.io-poco/src/SIOEventRegistry.cpp
@@ -1,15 +1,18 @@
 #include "SIOEventRegistry.h"
 
-SIOEventRegistry::SIOEventRegistry(void)
+using Poco::BasicEvent;
+using Poco::JSON::Object;
+
+sio_poco::SIOEventRegistry::SIOEventRegistry(void)
 {
 }
 
-
-SIOEventRegistry::~SIOEventRegistry(void)
+sio_poco::SIOEventRegistry::~SIOEventRegistry(void)
 {
 }
 
-bool SIOEventRegistry::registerEvent(const char *name, SIOEventTarget *target, callback c)
+bool 
+sio_poco::SIOEventRegistry::registerEvent(const char *name, SIOEventTarget *target, callback c)
 {
 	std::map<std::string,BasicEvent<Object::Ptr> *>::iterator it= mEventMap.find(std::string(name));
 	if(it != mEventMap.end())
@@ -33,7 +36,8 @@ bool SIOEventRegistry::registerEvent(const char *name, SIOEventTarget *target, c
 	return true;
 }
 
-void SIOEventRegistry::fireEvent(SIOClient *client, const char *name, Object::Ptr data)
+void 
+sio_poco::SIOEventRegistry::fireEvent(SIOClient *client, const char *name, Object::Ptr data)
 {
 
 	std::map<std::string,BasicEvent<Object::Ptr> *>::iterator it= mEventMap.find(std::string(name));

--- a/socket.io-poco/src/SIONotificationHandler.cpp
+++ b/socket.io-poco/src/SIONotificationHandler.cpp
@@ -14,12 +14,14 @@ using Poco::JSON::ParseHandler;
 using Poco::Dynamic::Var;
 using Poco::JSON::Array;
 using Poco::JSON::Object;
+using Poco::NotificationCenter;
+using Poco::Logger;
 
-SIONotificationHandler::SIONotificationHandler(void)
+sio_poco::SIONotificationHandler::SIONotificationHandler(void)
 {
 }
 
-SIONotificationHandler::SIONotificationHandler(NotificationCenter* nc)
+sio_poco::SIONotificationHandler::SIONotificationHandler(NotificationCenter* nc)
 {
 	_nCenter = nc;
 	registerCallbacks(_nCenter);
@@ -27,7 +29,7 @@ SIONotificationHandler::SIONotificationHandler(NotificationCenter* nc)
 	_logger = &(Logger::get("SIOClientLog"));
 }
 
-SIONotificationHandler::~SIONotificationHandler(void)
+sio_poco::SIONotificationHandler::~SIONotificationHandler(void)
 {
 	_nCenter->removeObserver(
 		Observer<SIONotificationHandler, SIOMessage>(*this, &SIONotificationHandler::handleMessage)
@@ -40,19 +42,22 @@ SIONotificationHandler::~SIONotificationHandler(void)
 		);
 }
 
-void SIONotificationHandler::handleMessage(SIOMessage* pNf)
+void 
+sio_poco::SIONotificationHandler::handleMessage(SIOMessage* pNf)
 {
 	_logger->information("handling message, message received: %s",pNf->getMsg());
 	pNf->release();
 }
 
-void SIONotificationHandler::handleJSONMessage(SIOJSONMessage* pNf)
+void 
+sio_poco::SIONotificationHandler::handleJSONMessage(SIOJSONMessage* pNf)
 {
 	_logger->information("handling JSON message");
 	pNf->release();
 }
 
-void SIONotificationHandler::handleEvent(SIOEvent* pNf)
+void 
+sio_poco::SIONotificationHandler::handleEvent(SIOEvent* pNf)
 {
 	_logger->information("handling Event");
 	_logger->information("data: %s", pNf->_data);
@@ -74,7 +79,8 @@ void SIONotificationHandler::handleEvent(SIOEvent* pNf)
 	pNf->release();
 }
 
-void SIONotificationHandler::registerCallbacks(NotificationCenter* nc)
+void 
+sio_poco::SIONotificationHandler::registerCallbacks(NotificationCenter* nc)
 {
 	_nCenter = nc;
 
@@ -89,7 +95,8 @@ void SIONotificationHandler::registerCallbacks(NotificationCenter* nc)
 		);
 }
 
-void SIONotificationHandler::setNCenter(NotificationCenter* nc)
+void 
+sio_poco::SIONotificationHandler::setNCenter(NotificationCenter* nc)
 {
 	_nCenter = nc;
 	registerCallbacks(_nCenter);


### PR DESCRIPTION
1. Fixed namespace pollution: fixes compatibility issues with user code if user does not use namespaces.
1. Added install in CMake.
1. Fixed static receive buffer in SIOClientImpl::receive() which caused a crash when the amount of incoming data was more than 1024 bytes. (Solves issue #9)